### PR TITLE
Added alternate path capability for imagehub.yaml file in imagehub.py

### DIFF
--- a/imagehub/imagehub.py
+++ b/imagehub/imagehub.py
@@ -15,15 +15,22 @@ import signal
 import logging
 import logging.handlers
 import traceback
+import argparse
 from tools.utils import clean_shutdown_when_killed
 from tools.utils import Patience
 from tools.hub import Settings
 from tools.hub import ImageHub
 
+# construct the argument parser and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-p", "--path", required=False,
+	help="path to imagehub.yaml file")
+args = vars(ap.parse_args())
+
 def main():
     # set up controlled shutdown when Kill Process or SIGTERM received
     signal.signal(signal.SIGTERM, clean_shutdown_when_killed)
-    settings = Settings()  # get settings from YAML file
+    settings = Settings(path=args["path"])  # get settings from YAML file
     hub = ImageHub(settings)  # start ImageWriter, Timers, etc.
     log = start_logging(hub)
     log.info('Starting imagehub.py')

--- a/imagehub/tools/utils.py
+++ b/imagehub/tools/utils.py
@@ -7,6 +7,7 @@ License: MIT, see LICENSE for more details.
 import time
 import signal
 import logging
+from sys import platform
 
 def clean_shutdown_when_killed(signum, *args):
     """Close all connections cleanly and log shutdown
@@ -60,11 +61,13 @@ class Patience:
         self.seconds = seconds
 
     def __enter__(self):
-        signal.signal(signal.SIGALRM, self.raise_timeout)
-        signal.alarm(self.seconds)
+        if platform != "win32":
+            signal.signal(signal.SIGALRM, self.raise_timeout)
+            signal.alarm(self.seconds)
 
     def __exit__(self, *args):
-        signal.alarm(0)    # disable alarm
+        if platform != "win32":
+            signal.alarm(0)    # disable alarm
 
     def raise_timeout(self, *args):
         raise Patience.Timeout()


### PR DESCRIPTION
Provided alternate means of defining imagehub.yaml file location via -path argument at startup.  The routine will startup normally by looking in the home directory if the -path isn't defined at startup.